### PR TITLE
Fix bug with multiple Contact folders with name $ContactFolderName

### DIFF
--- a/Module/GAL-Sync.psd1
+++ b/Module/GAL-Sync.psd1
@@ -67,6 +67,7 @@
     # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
     FunctionsToExport    = @(
         "Connect-GALSync"
+        "Delete-ContactFolder"
         "Get-ContactFolder"
         "Get-FolderContact"
         "Get-GALAADGroupMembers"

--- a/Module/Public/ContactFolder/func_Delete-ContactFolder.ps1
+++ b/Module/Public/ContactFolder/func_Delete-ContactFolder.ps1
@@ -1,0 +1,15 @@
+function Delete-ContactFolder {
+    param (
+        [CmdletBinding()]
+        [parameter(Mandatory)][string]$Mailbox,
+        [parameter(Mandatory)][object]$ContactFolder
+    )
+    try {
+        Write-VerboseEvent "Deleting ContactFolder $($ContactFolder.displayName) (ID: $($ContactFolder.id))"
+        New-GraphRequest -Method Delete -Endpoint "/users/$($Mailbox)/contactFolders/$($ContactFolder.id)"
+        return
+    }
+    catch {
+        throw (Format-ErrorCode $_).ErrorMessage
+    }
+}

--- a/Module/Public/ContactFolder/func_Get-ContactFolder.ps1
+++ b/Module/Public/ContactFolder/func_Get-ContactFolder.ps1
@@ -12,13 +12,25 @@ function Get-ContactFolder {
             $folderList = $folderList | Where-Object { $_.wellKnownName }
         }
         else { # if ContactFolderName is not filled in
-            $folderList = $folderList | Where-Object { $_.displayName -like $ContactFolderName }
+            $folderList = $folderList | Where-Object { $_.displayName -eq $ContactFolderName }
         }
         if (-not $folderList) {
             Write-VerboseEvent "Not able to find the contact folder $ContactFolderName for $Mailbox"
             return $false | Out-Null
         }
-        Write-VerboseEvent "Found folder $ContactFolderName, returning!"
+
+        # If there are multiple contact folders present with the same name,
+        # we try to delete every one of them, return false and re-create the sync 
+        # folder with the name $ContactFolderName later
+        if ($folderList.Count -gt 1) {
+            ForEach($folderEntry in $folderList) {
+                Delete-ContactFolder -Mailbox $Mailbox -ContactFolder $folderEntry
+            }
+            Write-VerboseEvent -Message "Sleeping a few seconds to wait for API update"
+            Start-Sleep (Get-Random -Minimum 5 -Maximum 15)
+            return $false | Out-Null
+        }
+
         $folderList | Add-Member -MemberType NoteProperty -Name "mailBox" -Value $Mailbox
         return $folderList
     }


### PR DESCRIPTION
This commit fixes a bug which was caused if there were multiple Contact folders with the desired sync folder name. In such case the Get-ContactFolder would return a list of objects and for that reason the following Graph API requests would fail.

This bug was discussed in #3


I introduce a new function `Delete-ContactFolder` to remove these duplicate entries as a workaround. Since this patch removes all the matching contact folders and the `Get-ContactFolder` will then return $false, the following code in `Sync-GALContacts` will then re-create the sync folder.