### PR TITLE
Enforce UTF-8 to fix encoding issues

### DIFF
--- a/Module/Public/func_New-GraphRequest.ps1
+++ b/Module/Public/func_New-GraphRequest.ps1
@@ -53,13 +53,13 @@ function New-GraphRequest {
             return $output
         }
         $output = @()
-        $request = Invoke-RestMethod @reqSplat
+        $request = Invoke-RestMethod -ContentType "application/json; charset=UTF-8" @reqSplat
         $output += (Check-OutputData $request)
         if ($request.'@odata.nextLink') {
             Write-VerboseEvent "Found @odata.nextLink"
             Write-VerboseEvent $request.'@odata.nextLink'
             do {
-                $request = Invoke-RestMethod $request.'@odata.nextLink' -Headers $script:galSyncData.GraphAuthHeader
+                $request = Invoke-RestMethod -ContentType "application/json; charset=UTF-8" $request.'@odata.nextLink' -Headers $script:galSyncData.GraphAuthHeader
                 $output += (Check-OutputData $request)
             } until (
                 (-not $request.'@odata.nextLink')


### PR DESCRIPTION
Fixes encoding issues with contact names or addresses containing for example nordic letter (å, ä, ö) by enforcing UTF-8 for raw Graph API requests.

This bug was also discussed in #3 .