### PR TITLE
Add GraphSDK functionality with "-UseGraphSDK" switch

### DIFF
--- a/Module/Public/ContactFolder/func_Delete-ContactFolder.ps1
+++ b/Module/Public/ContactFolder/func_Delete-ContactFolder.ps1
@@ -6,7 +6,11 @@ function Delete-ContactFolder {
     )
     try {
         Write-VerboseEvent "Deleting ContactFolder $($ContactFolder.displayName) (ID: $($ContactFolder.id))"
-        New-GraphRequest -Method Delete -Endpoint "/users/$($Mailbox)/contactFolders/$($ContactFolder.id)"
+        if ($UseGraphSDK) {
+            Remove-MgUserContactFolder -UserId $Mailbox -ContactFolderId $ContactFolder.id
+        } else {
+            New-GraphRequest -Method Delete -Endpoint "/users/$($Mailbox)/contactFolders/$($ContactFolder.id)"
+        }
         return
     }
     catch {

--- a/Module/Public/ContactFolder/func_Get-ContactFolder.ps1
+++ b/Module/Public/ContactFolder/func_Get-ContactFolder.ps1
@@ -6,7 +6,11 @@ function Get-ContactFolder {
     )
     try {
         Write-VerboseEvent "Getting folder $ContactFolderName"
-        $folderList = New-GraphRequest -Method Get -Endpoint "/users/$($Mailbox)/contactFolders?`$top=999" -Beta
+        $folderList = if ($UseGraphSDK) {
+            Get-MgUserContactFolder -UserId $Mailbox -Filter "displayName eq '$ContactFolderName'"
+        } else {
+            New-GraphRequest -Method Get -Endpoint "/users/$($Mailbox)/contactFolders?`$top=999" -Beta
+        }
         if (-not $ContactFolderName) {
             Write-VerboseEvent "Default contacts folder is querried"
             $folderList = $folderList | Where-Object { $_.wellKnownName }

--- a/Module/Public/ContactFolder/func_New-ContactFolder.ps1
+++ b/Module/Public/ContactFolder/func_New-ContactFolder.ps1
@@ -5,15 +5,22 @@ function New-ContactFolder {
         [string]$ContactFolderName
     )
     try {
-        Write-VerboseEvent "Getting parent ID"
-        $folderParentID = Get-ContactFolder -Mailbox $Mailbox | Select-Object -ExpandProperty id
-        Write-VerboseEvent "Parent ID: $folderParentID"
-        $contactFolderBody = @{
-            displayName    = $ContactFolderName
-            parentFolderId = $folderParentID
-        }
         Write-VerboseEvent -Message "Creating new folder $ContactFolderName"
-        $contactFolder = New-GraphRequest -Method Post -Endpoint "/users/$($Mailbox)/contactFolders" -Body $contactFolderBody -Beta
+        $contactFolder = if ($UseGraphSDK) {
+            $contactFolderBody = @{
+                displayName    = $ContactFolderName
+            }
+            New-MgUserContactFolder -UserId $Mailbox -BodyParameter $contactFolderBody
+        } else {
+            Write-VerboseEvent "Getting parent ID"
+            $folderParentID = Get-ContactFolder -Mailbox $Mailbox | Select-Object -ExpandProperty id
+            Write-VerboseEvent "Parent ID: $folderParentID"
+            $contactFolderBody = @{
+                displayName    = $ContactFolderName
+                parentFolderId = $folderParentID
+            }
+            New-GraphRequest -Method Post -Endpoint "/users/$($Mailbox)/contactFolders" -Body $contactFolderBody -Beta
+        }
         Write-VerboseEvent -Message "Created folder"
         $contactFolder | Add-Member -MemberType NoteProperty -Name "mailBox" -Value $Mailbox
         # because graph is graph...

--- a/Module/Public/Sync/func_Get-FolderContact.ps1
+++ b/Module/Public/Sync/func_Get-FolderContact.ps1
@@ -5,7 +5,11 @@ function Get-FolderContact {
         [string]$DisplayName
     )
     try {
-        $contactList = New-GraphRequest -Method Get -Endpoint "/users/$($ContactFolder.mailBox)/contactfolders/$($contactFolder.id)/contacts?`$top=999"
+        $contactList = if ($UseGraphSDK) {
+            Get-MgUserContactFolderContact -UserId $ContactFolder.mailBox -ContactFolderId $contactFolder.id -All
+        } else {
+            New-GraphRequest -Method Get -Endpoint "/users/$($ContactFolder.mailBox)/contactfolders/$($contactFolder.id)/contacts?`$top=999"
+        }
         if (-not $contactList) {
             Write-VerboseEvent "Not able to find contacts in folder"
             return

--- a/Module/Public/Sync/func_New-FolderContact.ps1
+++ b/Module/Public/Sync/func_New-FolderContact.ps1
@@ -16,8 +16,12 @@ function New-FolderContact {
     if ($contact.homePhones) { $contactBody.homePhones = $contact.homePhones }
     if ($contact.businessPhones) { $contactBody.businessPhones = $contact.businessPhones }
 
-    try { 
-        New-GraphRequest -Method Post -Endpoint "/users/$($ContactFolder.mailBox)/contactFolders/$($ContactFolder.id)/contacts" -Body $contactBody | Out-Null
+    try {
+        if ($UseGraphSDK) {
+            New-MgUserContactFolderContact -UserId $ContactFolder.mailBox -ContactFolderId $ContactFolder.id -BodyParameter $contactBody
+        } else {
+            New-GraphRequest -Method Post -Endpoint "/users/$($ContactFolder.mailBox)/contactFolders/$($ContactFolder.id)/contacts" -Body $contactBody | Out-Null
+        }
         Write-VerboseEvent "Created contact $($Contact.displayName)"
         return $true
     }

--- a/Module/Public/Sync/func_Remove-FolderContact.ps1
+++ b/Module/Public/Sync/func_Remove-FolderContact.ps1
@@ -7,7 +7,11 @@ function Remove-FolderContact {
     process {
         foreach ($contactItem in $Contact) {
             try {
-                New-GraphRequest -Method Delete -Endpoint "/users/$($ContactFolder.mailBox)/contactFolders/$($ContactFolder.id)/contacts/$($contactItem.id)" | Out-Null
+                if ($UseGraphSDK) {
+                    Remove-MgUserContactFolderContact -UserId $ContactFolder.mailBox -ContactFolderId $ContactFolder.id -ContactId $contactItem.id
+                } else {
+                    New-GraphRequest -Method Delete -Endpoint "/users/$($ContactFolder.mailBox)/contactFolders/$($ContactFolder.id)/contacts/$($contactItem.id)" | Out-Null
+                }
                 Write-VerboseEvent "Deleted contact $($contactItem.displayName)"
                 return $true
             }

--- a/Module/Public/Sync/func_Update-FolderContact.ps1
+++ b/Module/Public/Sync/func_Update-FolderContact.ps1
@@ -15,7 +15,11 @@ function Update-FolderContact {
         # add these based on pressence
         # if ($Contact.homePhones) { $updateContactBody.homePhones = $NewContact.homePhones }
         if ($Contact.businessPhones) { $updateContactBody.businessPhones = $Contact.businessPhones }
-        New-GraphRequest -Method Patch -Endpoint "/users/$($ContactFolder.mailBox)/contactFolders/$($ContactFolder.id)/contacts/$($Contact.id)" -Body $updateContactBody | Out-Null
+        if ($UseGraphSDK) {
+            Update-MgUserContactFolderContact -UserId $ContactFolder.mailBox -ContactFolderId $ContactFolder.id -ContactId $Contact.id -BodyParameter $updateContactBody
+        } else {
+            New-GraphRequest -Method Patch -Endpoint "/users/$($ContactFolder.mailBox)/contactFolders/$($ContactFolder.id)/contacts/$($Contact.id)" -Body $updateContactBody | Out-Null
+        }
         Write-VerboseEvent "Updated contact $($Contact.displayName)"
         return $true
     }

--- a/Module/Public/func_Get-GALContacts.ps1
+++ b/Module/Public/func_Get-GALContacts.ps1
@@ -6,7 +6,11 @@ function Get-GALContacts {
     )
     try {
         Write-VerboseEvent "Getting GAL contacts"
-        $allContacts = New-GraphRequest -Endpoint "/users?`$select=*&`$top=999" -Beta
+        $allContacts = if ($UseGraphSDK) {
+            Get-MgUser -All
+        } else {
+            New-GraphRequest -Endpoint "/users?`$select=*&`$top=999" -Beta
+        }
         if (-not $ContactsWithoutPhoneNumber) {
             $allContacts = $allContacts | Where-Object { $_.businessPhones -or $_.mobilePhone }
         }
@@ -23,9 +27,9 @@ function Get-GALContacts {
                 jobTitle       = $_.jobTitle                
                 department     = $_.department
                 # homePhones     = if (-not $_.homePhones) { @() } else { @($_.homePhones) }
-                emailAddresses = @([pscustomobject]@{
-                        name    = $_.displayName
-                        address = $_.mail 
+                emailAddresses = @(@{
+                        name    = $_.mail
+                        address = $_.mail
                     })
             }
         }

--- a/Sync-Contacts.ps1
+++ b/Sync-Contacts.ps1
@@ -8,12 +8,18 @@ param (
     [switch]$Directory,
     [string]$LogPath,
     [switch]$ContactsWithoutPhoneNumber,
-    [switch]$ContactsWithoutEmail
+    [switch]$ContactsWithoutEmail,
+    [switch]$UseGraphSDK
 )
+
+Set-Variable -Name UseGraphSDK -Value $UseGraphSDK -Scope Global -Option ReadOnly
 
 if ($LogPath) {
     Start-Transcript -OutputDirectory $LogPath
 }
+
+Write-Verbose "Using $(If ($UseGraphSDK) {"Graph SDK"} Else {"raw REST requests"}) for connection"
+If ($UseGraphSDK) { Import-Module Microsoft.Graph.PersonalContacts }
 
 Import-Module .\Module\GAL-Sync.psm1 -Force
 Connect-GALSync -CredentialFile $CredentialPath -Tenant $Tenant


### PR DESCRIPTION
@JeshuaEdgar , please check this commit thoroughly, since I've changed at least these things on top of adding GraphSDK switch:
- Contact comparison. Especially the email part. It now force-converts the folder contacts' email lists into hashtables, since I was not able to make comparison working with GraphSDK (It is some custom type object when retrieved via GraphSDK)
- Part of contact comparison was to change the contact data structure. Email address list is not a `pscustomobject` but a default-form hashtable(?). With `pscustomobject` I was not able to get the comparison working (even with raw requests).
- I remove contacts with duplicate `displayName`s. Again I was facing issues when syncing a GAL with multiple different users with same `displayName`s.

I might still upload more patches in the following weeks when this thing goes into production. Especially the address fields etc. might get populated ;)