### PR TITLE
Add possibility to filter GAL Contacts

### DIFF
--- a/Module/Public/Sync/func_New-FolderContact.ps1
+++ b/Module/Public/Sync/func_New-FolderContact.ps1
@@ -10,7 +10,9 @@ function New-FolderContact {
         mobilePhone    = $contact.mobilePhone
         jobTitle       = $contact.jobTitle
         department     = $contact.department
+        companyName    = $contact.companyName
         emailAddresses = $contact.emailAddresses
+        businessAddress = $contact.businessAddress
     }
     # add these based on pressence
     if ($contact.homePhones) { $contactBody.homePhones = $contact.homePhones }

--- a/Module/Public/Sync/func_Update-FolderContact.ps1
+++ b/Module/Public/Sync/func_Update-FolderContact.ps1
@@ -10,7 +10,9 @@ function Update-FolderContact {
             surname        = $Contact.surname
             jobTitle       = $Contact.jobTitle
             department     = $Contact.department
+            companyName    = $Contact.companyName
             emailAddresses = $Contact.emailAddresses
+            businessAddress = $Contact.businessAddress
         }
         # add these based on pressence
         # if ($Contact.homePhones) { $updateContactBody.homePhones = $NewContact.homePhones }

--- a/Module/Public/func_Sync-GALContacts.ps1
+++ b/Module/Public/func_Sync-GALContacts.ps1
@@ -33,11 +33,11 @@ function Sync-GALContacts {
     }
 
     if ($contactsInFolder) {
-        $removeContacts = $contactsInFolder | Where-Object { $_.displayName -notin $ContactList.displayName }
+        $removeContacts = @()
+        $removeContacts += $contactsInFolder | Where-Object { $_.displayName -notin $ContactList.displayName }
         # Remove contacts that have duplicate displayNames. This is the only way to correctly sync
         # contacts when using displayName as the "primary key"
         $removeContacts += $contactsInFolder | Group-Object displayName | Where-Object { $_.Count -gt 1 } | ForEach-Object { $_.Group }
-
         if ($removeContacts) {
             foreach ($contact in $removeContacts) {
                 try { 
@@ -49,7 +49,6 @@ function Sync-GALContacts {
                 }
             }
         }
-
         # Get contacts in that folder again (after we've possibly removed some of them)
         try {
             $contactsInFolder = Get-FolderContact -ContactFolder $contactFolder

--- a/Sync-Contacts.ps1
+++ b/Sync-Contacts.ps1
@@ -9,8 +9,25 @@ param (
     [string]$LogPath,
     [switch]$ContactsWithoutPhoneNumber,
     [switch]$ContactsWithoutEmail,
-    [switch]$UseGraphSDK
+    [string]$ContactsFilter,
+    [switch]$UseGraphSDK,
+    [string]$ConfigFile
 )
+
+if ($ConfigFile) {
+    $ConfObj = Get-Content -Raw -Path $ConfigFile | ConvertFrom-Json
+    If ($null -ne $ConfObj.CredentialPath) { $CredentialPath = $ConfObj.CredentialPath }
+    If ($null -ne $ConfObj.Tenant) { $Tenant = $ConfObj.Tenant }
+    If ($null -ne $ConfObj.ContactFolderName) { $ContactFolderName = $ConfObj.ContactFolderName }
+    If ($null -ne $ConfObj.AzureADGroup) { $AzureADGroup = $ConfObj.AzureADGroup }
+    If ($null -ne $ConfObj.MailboxList) { $MailboxList = $ConfObj.MailboxList }
+    If ($null -ne $ConfObj.Directory) { $Directory = $ConfObj.Directory }
+    If ($null -ne $ConfObj.LogPath) { $LogPath = $ConfObj.LogPath }
+    If ($null -ne $ConfObj.ContactsWithoutPhoneNumber) { $ContactsWithoutPhoneNumber = $ConfObj.ContactsWithoutPhoneNumber }
+    If ($null -ne $ConfObj.ContactsWithoutEmail) { $ContactsWithoutEmail = $ConfObj.ContactsWithoutEmail }
+    If ($null -ne $ConfObj.ContactsFilter) { $ContactsFilter = $ConfObj.ContactsFilter }
+    If ($null -ne $ConfObj.UseGraphSDK) { $UseGraphSDK = $ConfObj.UseGraphSDK }
+}
 
 Set-Variable -Name UseGraphSDK -Value $UseGraphSDK -Scope Global -Option ReadOnly
 
@@ -30,7 +47,7 @@ elseif ($AzureADGroup) { $mailBoxesToSync = Get-GALAADGroupMembers -Name $AzureA
 elseif ($MailboxList -is [array]) { $mailBoxesToSync = $MailboxList }
 else { Write-Error "No valid mailbox input"; Read-Host; exit 1 }
 
-$GALContacts = Get-GALContacts -ContactsWithoutPhoneNumber $ContactsWithoutPhoneNumber -ContactsWithoutEmail $ContactsWithoutEmail
+$GALContacts = Get-GALContacts -ContactsWithoutPhoneNumber $ContactsWithoutPhoneNumber -ContactsWithoutEmail $ContactsWithoutEmail -ContactsFilter $ContactsFilter
 
 foreach ($mailBox in $mailBoxesToSync) {
     try {

--- a/Sync-Contacts.ps1
+++ b/Sync-Contacts.ps1
@@ -1,8 +1,8 @@
 param (
     [CmdletBinding()]
-    [parameter(Mandatory)][System.IO.FileInfo]$CredentialPath,
-    [parameter(Mandatory)][string]$Tenant,
-    [parameter(Mandatory)][string]$ContactFolderName,
+    [System.IO.FileInfo]$CredentialPath,
+    [string]$Tenant,
+    [string]$ContactFolderName,
     [string]$AzureADGroup,
     [string[]]$MailboxList,
     [switch]$Directory,
@@ -10,6 +10,7 @@ param (
     [switch]$ContactsWithoutPhoneNumber,
     [switch]$ContactsWithoutEmail,
     [string]$ContactsFilter,
+    [string]$UsersFilter,
     [switch]$UseGraphSDK,
     [string]$ConfigFile
 )
@@ -26,6 +27,7 @@ if ($ConfigFile) {
     If ($null -ne $ConfObj.ContactsWithoutPhoneNumber) { $ContactsWithoutPhoneNumber = $ConfObj.ContactsWithoutPhoneNumber }
     If ($null -ne $ConfObj.ContactsWithoutEmail) { $ContactsWithoutEmail = $ConfObj.ContactsWithoutEmail }
     If ($null -ne $ConfObj.ContactsFilter) { $ContactsFilter = $ConfObj.ContactsFilter }
+    If ($null -ne $ConfObj.UsersFilter) { $UsersFilter = $ConfObj.UsersFilter }
     If ($null -ne $ConfObj.UseGraphSDK) { $UseGraphSDK = $ConfObj.UseGraphSDK }
 }
 
@@ -42,7 +44,7 @@ Import-Module .\Module\GAL-Sync.psm1 -Force
 Connect-GALSync -CredentialFile $CredentialPath -Tenant $Tenant
 
 # Get users based on input
-if ($Directory) { $mailBoxesToSync = (Get-GALContacts -ContactsWithoutPhoneNumber $true).emailaddresses | Select-Object -ExpandProperty address }
+if ($Directory) { $mailBoxesToSync = (Get-GALContacts -ContactsWithoutPhoneNumber $true -ContactsFilter $UsersFilter).emailaddresses | Select-Object -ExpandProperty address }
 elseif ($AzureADGroup) { $mailBoxesToSync = Get-GALAADGroupMembers -Name $AzureADGroup | Select-Object -ExpandProperty mail }
 elseif ($MailboxList -is [array]) { $mailBoxesToSync = $MailboxList }
 else { Write-Error "No valid mailbox input"; Read-Host; exit 1 }

--- a/settings.json
+++ b/settings.json
@@ -1,0 +1,12 @@
+{
+    "CredentialPath": "Credentials\\credential.cred",
+    "Tenant": "abc-def-ghi",
+    "ContactFolderName": "syncedpeople",
+    "ContactsWithoutPhoneNumber": true,
+    "ContactsWithoutEmail": true,
+    "ContactsFilter": "companyName eq 'ACME Corp'",
+    "LogPath": ".\\Logs",
+    "Verbose": true,
+    "MailboxList": "my-email@acme.corp",
+    "UseGraphSDK": true
+}

--- a/settings.json
+++ b/settings.json
@@ -5,6 +5,7 @@
     "ContactsWithoutPhoneNumber": true,
     "ContactsWithoutEmail": true,
     "ContactsFilter": "companyName eq 'ACME Corp'",
+    "UsersFilter": "companyName eq 'ACME Corp'",
     "LogPath": ".\\Logs",
     "Verbose": true,
     "MailboxList": "my-email@acme.corp",


### PR DESCRIPTION
Also added settings parsing feature, settings can be stored in a json file and loaded with the `-ConfigFile` param

I had to resort to using a config file, because when passing UTF-8 characters via CMD (the .bat file) to powershell, the encoding would break. That's why the settings file includes the new `ContactsFilter` variable, which acts as a parameter to `Get-MgUser`'s `-Filter` option. (https://learn.microsoft.com/en-us/powershell/module/microsoft.graph.users/get-mguser?view=graph-powershell-1.0#-filter)

**NOTE:** The filtering does not work with raw requests (yet).